### PR TITLE
feat: add save and load rankings

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -3,9 +3,15 @@ import { Search, Download, Upload, Trash2, Database } from "lucide-react";
 
 interface DashboardHeaderProps {
   onSearch: (query: string) => void;
+  onSaveRankings: () => void;
+  onLoadRankings: () => void;
 }
 
-export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
+export function DashboardHeader({
+  onSearch,
+  onSaveRankings,
+  onLoadRankings,
+}: DashboardHeaderProps) {
   return (
     <div className="space-y-6">
       {/* Main Header */}
@@ -22,11 +28,21 @@ export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
           </div>
           
           <div className="flex items-center gap-3">
-            <Button variant="dynasty" size="sm" className="gap-2">
+            <Button
+              variant="dynasty"
+              size="sm"
+              className="gap-2"
+              onClick={onSaveRankings}
+            >
               <Upload className="w-4 h-4" />
               Save Rankings
             </Button>
-            <Button variant="outline" size="sm" className="gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={onLoadRankings}
+            >
               <Download className="w-4 h-4" />
               Load Rankings
             </Button>

--- a/src/components/PlayerRankingsTable.tsx
+++ b/src/components/PlayerRankingsTable.tsx
@@ -1,17 +1,14 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
-import { useEffect, useState, type DragEvent } from "react";
-
-interface Player {
-  player: string;
-  pos: string;
-  ecr: number;
-  age: number;
-  rdr_team: string;
-  team_full: string;
-  years_of_experience: number | null;
-}
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+  type DragEvent,
+} from "react";
+import type { Player } from "@/hooks/usePlayerData";
 
 interface PlayerRankingsTableProps {
   title: string;
@@ -19,6 +16,11 @@ interface PlayerRankingsTableProps {
   players: Player[];
   variant: "veterans" | "young";
   onAddPlayer: () => void;
+  onReorder?: () => void;
+}
+
+export interface PlayerRankingsTableHandle {
+  getPlayerList: () => Player[];
 }
 
 const tierColors: Record<string, string> = {
@@ -29,13 +31,17 @@ const tierColors: Record<string, string> = {
   "Tier 5": "bg-gray-100 text-tier-watch",
 };
 
-export function PlayerRankingsTable({
+export const PlayerRankingsTable = forwardRef<
+  PlayerRankingsTableHandle,
+  PlayerRankingsTableProps
+>(function PlayerRankingsTable({
   title,
   subtitle,
   players,
   variant,
-  onAddPlayer
-}: PlayerRankingsTableProps) {
+  onAddPlayer,
+  onReorder,
+}, ref) {
   const headerColor = variant === "veterans" ? "bg-veterans" : "bg-young-talent";
 
   // Maintain a local copy of players so we can reorder them
@@ -59,7 +65,12 @@ export function PlayerRankingsTable({
     const [moved] = updated.splice(dragIndex, 1);
     updated.splice(dropIndex, 0, moved);
     setPlayerList(updated);
+    onReorder?.();
   };
+
+  useImperativeHandle(ref, () => ({
+    getPlayerList: () => playerList,
+  }));
   
   return (
     <div className="bg-gradient-card rounded-lg shadow-card overflow-hidden">
@@ -159,7 +170,7 @@ export function PlayerRankingsTable({
       </div>
     </div>
   );
-}
+});
 
 function getTierFromRank(rank: number): string {
   if (rank <= 5) return "Tier 1";

--- a/src/hooks/usePlayerData.ts
+++ b/src/hooks/usePlayerData.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 
-interface Player {
+export interface Player {
   player: string;
   pos: string;
   ecr: number;
@@ -40,7 +40,15 @@ export function usePlayerData() {
 
       // Transform data with real years_of_experience from the view
       // This is the correct logic now that we have the proper data
-      const transformedPlayers = (data || []).map((row: any) => ({
+      interface Row {
+        player: string;
+        pos: string;
+        ecr: number;
+        team: string;
+        years_of_experience: number | null;
+      }
+
+      const transformedPlayers = (data || []).map((row: Row) => ({
         player: row.player,
         pos: row.pos,
         ecr: Number(row.ecr),
@@ -102,6 +110,7 @@ export function usePlayerData() {
     getVeteranPlayers,
     getYoungPlayers,
     searchPlayers,
-    refetch: fetchPlayers
+    refetch: fetchPlayers,
+    setPlayers
   };
 }


### PR DESCRIPTION
## Summary
- add save/load ranking buttons to header
- implement CSV export and import with unsaved change warning
- expose player data for replacements and table ranking hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in components/ui/command.tsx, components/ui/textarea.tsx and @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d2fea6a2c83248ecb72b014162a7d