### PR TITLE
feat: add save and load rankings

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -3,9 +3,11 @@ import { Search, Download, Upload, Trash2, Database } from "lucide-react";
 
 interface DashboardHeaderProps {
   onSearch: (query: string) => void;
+  onSave: () => void;
+  onLoad: () => void;
 }
 
-export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
+export function DashboardHeader({ onSearch, onSave, onLoad }: DashboardHeaderProps) {
   return (
     <div className="space-y-6">
       {/* Main Header */}
@@ -22,11 +24,11 @@ export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
           </div>
           
           <div className="flex items-center gap-3">
-            <Button variant="dynasty" size="sm" className="gap-2">
+            <Button variant="dynasty" size="sm" className="gap-2" onClick={onSave}>
               <Upload className="w-4 h-4" />
               Save Rankings
             </Button>
-            <Button variant="outline" size="sm" className="gap-2">
+            <Button variant="outline" size="sm" className="gap-2" onClick={onLoad}>
               <Download className="w-4 h-4" />
               Load Rankings
             </Button>

--- a/src/components/DynastyDashboard.tsx
+++ b/src/components/DynastyDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef, type ChangeEvent } from "react";
 import { DashboardHeader } from "./DashboardHeader";
 import { TierGuide } from "./TierGuide";
 import { PositionTabs } from "./PositionTabs";
@@ -7,9 +7,23 @@ import { PlayerRankingsTable } from "./PlayerRankingsTable";
 import { DataStatus } from "./debug/DataStatus";
 import { usePlayerData } from "@/hooks/usePlayerData";
 
+interface Player {
+  player: string;
+  pos: string;
+  ecr: number;
+  age: number;
+  rdr_team: string;
+  team_full: string;
+  years_of_experience: number | null;
+}
+
 export function DynastyDashboard() {
   const [selectedPosition, setSelectedPosition] = useState("QB");
   const [searchQuery, setSearchQuery] = useState("");
+  const [veteranRanking, setVeteranRanking] = useState<Player[]>([]);
+  const [youngRanking, setYoungRanking] = useState<Player[]>([]);
+  const [isEdited, setIsEdited] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   
   const { 
     players, 
@@ -33,6 +47,33 @@ export function DynastyDashboard() {
   const handleRetry = async () => {
     await refetch();
   };
+  const positionPlayers = searchQuery
+    ? searchPlayers(searchQuery).filter(p => selectedPosition === "ALL" ? true : p.pos === selectedPosition)
+    : selectedPosition === "ALL"
+      ? players
+      : getPlayersByPosition(selectedPosition);
+    
+  const veteranPlayers = selectedPosition === "ALL"
+    ? players.filter(p => p.years_of_experience !== null && p.years_of_experience >= 2)
+    : getVeteranPlayers(selectedPosition);
+
+  const youngPlayers = selectedPosition === "ALL"
+    ? players.filter(p => p.years_of_experience === null || p.years_of_experience <= 1)
+    : getYoungPlayers(selectedPosition);
+
+  useEffect(() => {
+    setVeteranRanking(veteranPlayers);
+    setYoungRanking(youngPlayers);
+    setIsEdited(false);
+  }, [veteranPlayers, youngPlayers]);
+
+  const filteredVeterans = searchQuery
+    ? veteranRanking.filter(p => p.player.toLowerCase().includes(searchQuery.toLowerCase()))
+    : veteranRanking;
+
+  const filteredYoung = searchQuery
+    ? youngRanking.filter(p => p.player.toLowerCase().includes(searchQuery.toLowerCase()))
+    : youngRanking;
 
   if (loading) {
     return (
@@ -54,19 +95,19 @@ export function DynastyDashboard() {
             <h2 className="text-xl font-semibold text-foreground mb-2">Database Connection Issue</h2>
             <p className="text-destructive mb-4">{error}</p>
             <div className="text-sm text-muted-foreground mb-6">
-              This usually happens when the database query takes too long. 
+              This usually happens when the database query takes too long.
               We're working with large datasets, so please try again.
             </div>
           </div>
           <div className="space-y-3">
-            <button 
+            <button
               onClick={handleRetry}
               className="bg-primary text-primary-foreground px-6 py-2 rounded-lg hover:bg-primary/90 transition-colors block w-full"
             >
               Retry Connection
             </button>
-            <button 
-              onClick={() => window.location.reload()} 
+            <button
+              onClick={() => window.location.reload()}
               className="text-muted-foreground hover:text-foreground transition-colors text-sm"
             >
               Full Page Reload
@@ -77,32 +118,122 @@ export function DynastyDashboard() {
     );
   }
 
-  const positionPlayers = searchQuery
-    ? searchPlayers(searchQuery).filter(p => selectedPosition === "ALL" ? true : p.pos === selectedPosition)
-    : selectedPosition === "ALL"
-      ? players
-      : getPlayersByPosition(selectedPosition);
-    
-  const veteranPlayers = selectedPosition === "ALL"
-    ? players.filter(p => p.years_of_experience !== null && p.years_of_experience >= 2)
-    : getVeteranPlayers(selectedPosition);
+  const handleReorderVeterans = (list: Player[]) => {
+    setVeteranRanking(list);
+    setIsEdited(true);
+  };
 
-  const youngPlayers = selectedPosition === "ALL"
-    ? players.filter(p => p.years_of_experience === null || p.years_of_experience <= 1)
-    : getYoungPlayers(selectedPosition);
+  const handleReorderYoung = (list: Player[]) => {
+    setYoungRanking(list);
+    setIsEdited(true);
+  };
 
-  const filteredVeterans = searchQuery
-    ? veteranPlayers.filter(p => p.player.toLowerCase().includes(searchQuery.toLowerCase()))
-    : veteranPlayers;
+  const handleSaveRankings = () => {
+    const rows: string[][] = [[
+      "rank",
+      "player",
+      "pos",
+      "ecr",
+      "age",
+      "rdr_team",
+      "team_full",
+      "years_of_experience",
+      "category"
+    ]];
+    veteranRanking.forEach((p, idx) => {
+      rows.push([
+        String(idx + 1),
+        p.player,
+        p.pos,
+        String(p.ecr),
+        String(p.age),
+        p.rdr_team,
+        p.team_full,
+        p.years_of_experience === null ? "" : String(p.years_of_experience),
+        "veterans"
+      ]);
+    });
+    youngRanking.forEach((p, idx) => {
+      rows.push([
+        String(idx + 1),
+        p.player,
+        p.pos,
+        String(p.ecr),
+        String(p.age),
+        p.rdr_team,
+        p.team_full,
+        p.years_of_experience === null ? "" : String(p.years_of_experience),
+        "young"
+      ]);
+    });
+    // eslint-disable-next-line no-useless-escape
+    const csv = rows.map(r => r.map(v => `\"${v}\"`).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "rankings.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    setIsEdited(false);
+  };
 
-  const filteredYoung = searchQuery
-    ? youngPlayers.filter(p => p.player.toLowerCase().includes(searchQuery.toLowerCase()))
-    : youngPlayers;
+  const handleLoadClick = () => {
+    if (isEdited && !window.confirm("Loading new rankings will replace current data. Continue?")) {
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = event => {
+      const text = event.target?.result;
+      if (typeof text !== "string") return;
+      const lines = text.trim().split(/\r?\n/);
+      const [headerLine, ...rows] = lines;
+      const headers = headerLine.split(",").map(h => h.replace(/^"|"$/g, ""));
+      const veterans: { player: Player; rank: number }[] = [];
+      const young: { player: Player; rank: number }[] = [];
+      rows.forEach(line => {
+        if (!line.trim()) return;
+        const values = line.split(",").map(v => v.replace(/^"|"$/g, ""));
+        const entry: Record<string, string> = {};
+        headers.forEach((h, i) => {
+          entry[h] = values[i] || "";
+        });
+        const player: Player = {
+          player: entry.player,
+          pos: entry.pos,
+          ecr: Number(entry.ecr),
+          age: Number(entry.age),
+          rdr_team: entry.rdr_team,
+          team_full: entry.team_full,
+          years_of_experience: entry.years_of_experience ? Number(entry.years_of_experience) : null
+        };
+        const rank = Number(entry.rank);
+        if (entry.category === "veterans") {
+          veterans.push({ player, rank });
+        } else {
+          young.push({ player, rank });
+        }
+      });
+      setVeteranRanking(veterans.sort((a, b) => a.rank - b.rank).map(v => v.player));
+      setYoungRanking(young.sort((a, b) => a.rank - b.rank).map(v => v.player));
+      setIsEdited(false);
+    };
+    reader.readAsText(file);
+    e.target.value = "";
+  };
 
   return (
     <div className="min-h-screen bg-gradient-background">
       <div className="container mx-auto px-4 py-6 space-y-6">
-        <DashboardHeader onSearch={handleSearch} />
+        <DashboardHeader onSearch={handleSearch} onSave={handleSaveRankings} onLoad={handleLoadClick} />
         
         <TierGuide />
         
@@ -125,16 +256,25 @@ export function DynastyDashboard() {
             players={filteredVeterans}
             variant="veterans"
             onAddPlayer={handleAddPlayer}
+            onReorder={handleReorderVeterans}
           />
-          
+
           <PlayerRankingsTable
             title="Young Talent"
             subtitle="Rookies & Sophomores"
             players={filteredYoung}
             variant="young"
             onAddPlayer={handleAddPlayer}
+            onReorder={handleReorderYoung}
           />
         </div>
+        <input
+          type="file"
+          accept=".csv"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          style={{ display: "none" }}
+        />
       </div>
       <DataStatus />
     </div>

--- a/src/components/PlayerRankingsTable.tsx
+++ b/src/components/PlayerRankingsTable.tsx
@@ -19,6 +19,7 @@ interface PlayerRankingsTableProps {
   players: Player[];
   variant: "veterans" | "young";
   onAddPlayer: () => void;
+  onReorder: (players: Player[]) => void;
 }
 
 const tierColors: Record<string, string> = {
@@ -34,7 +35,8 @@ export function PlayerRankingsTable({
   subtitle,
   players,
   variant,
-  onAddPlayer
+  onAddPlayer,
+  onReorder
 }: PlayerRankingsTableProps) {
   const headerColor = variant === "veterans" ? "bg-veterans" : "bg-young-talent";
 
@@ -59,6 +61,7 @@ export function PlayerRankingsTable({
     const [moved] = updated.splice(dragIndex, 1);
     updated.splice(dropIndex, 0, moved);
     setPlayerList(updated);
+    onReorder(updated);
   };
   
   return (


### PR DESCRIPTION
## Summary
- add save and load ranking buttons to header
- enable drag reorder callbacks and csv export
- import rankings from csv with overwrite warning

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in existing files)*
- `npx eslint src/components/DashboardHeader.tsx src/components/PlayerRankingsTable.tsx src/components/DynastyDashboard.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d2fea6a2c83248ecb72b014162a7d