### PR TITLE
feat: add player management and clear all

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -3,9 +3,17 @@ import { Search, Download, Upload, Trash2, Database } from "lucide-react";
 
 interface DashboardHeaderProps {
   onSearch: (query: string) => void;
+  onSaveRankings: () => void;
+  onLoadRankings: () => void;
+  onClearAll: () => void;
 }
 
-export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
+export function DashboardHeader({
+  onSearch,
+  onSaveRankings,
+  onLoadRankings,
+  onClearAll,
+}: DashboardHeaderProps) {
   return (
     <div className="space-y-6">
       {/* Main Header */}
@@ -22,11 +30,21 @@ export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
           </div>
           
           <div className="flex items-center gap-3">
-            <Button variant="dynasty" size="sm" className="gap-2">
+            <Button
+              variant="dynasty"
+              size="sm"
+              className="gap-2"
+              onClick={onSaveRankings}
+            >
               <Upload className="w-4 h-4" />
               Save Rankings
             </Button>
-            <Button variant="outline" size="sm" className="gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={onLoadRankings}
+            >
               <Download className="w-4 h-4" />
               Load Rankings
             </Button>
@@ -34,7 +52,12 @@ export function DashboardHeader({ onSearch }: DashboardHeaderProps) {
               <Download className="w-4 h-4" />
               Export
             </Button>
-            <Button variant="outline" size="sm" className="gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={onClearAll}
+            >
               <Trash2 className="w-4 h-4" />
               Clear All
             </Button>

--- a/src/components/DynastyDashboard.tsx
+++ b/src/components/DynastyDashboard.tsx
@@ -5,29 +5,185 @@ import { PositionTabs } from "./PositionTabs";
 import { PositionStats } from "./PositionStats";
 import { PlayerRankingsTable } from "./PlayerRankingsTable";
 import { DataStatus } from "./debug/DataStatus";
-import { usePlayerData } from "@/hooks/usePlayerData";
+import { PlayerFormDialog } from "./PlayerFormDialog";
+import { usePlayerData, type Player } from "@/hooks/usePlayerData";
 
 export function DynastyDashboard() {
   const [selectedPosition, setSelectedPosition] = useState("QB");
   const [searchQuery, setSearchQuery] = useState("");
   
-  const { 
-    players, 
-    loading, 
+  const {
+    players,
+    loading,
     error,
     getPlayersByPosition,
     getVeteranPlayers,
     getYoungPlayers,
     searchPlayers,
-    refetch
+    refetch,
+    setPlayers,
   } = usePlayerData();
+
+  const [isDirty, setIsDirty] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingPlayer, setEditingPlayer] = useState<Player | null>(null);
+
+  const isVeteran = (p: Player) =>
+    p.years_of_experience !== null && p.years_of_experience >= 2;
 
   const handleSearch = (query: string) => {
     setSearchQuery(query);
   };
 
   const handleAddPlayer = () => {
-    console.log("Add player functionality to be implemented");
+    setEditingPlayer(null);
+    setDialogOpen(true);
+  };
+
+  const handleEditPlayer = (player: Player) => {
+    setEditingPlayer(player);
+    setDialogOpen(true);
+  };
+
+  const handleSavePlayer = (player: Player) => {
+    setPlayers(prev => {
+      const exists = prev.some(p => p.player === player.player);
+      if (exists) {
+        return prev.map(p => (p.player === player.player ? player : p));
+      }
+      const veterans = prev.filter(isVeteran);
+      const young = prev.filter(p => !isVeteran(p));
+      if (isVeteran(player)) {
+        return [...veterans, player, ...young];
+      }
+      return [...veterans, ...young, player];
+    });
+    setDialogOpen(false);
+    setIsDirty(true);
+  };
+
+  const handleReorder = (updated: Player[], variant: "veterans" | "young") => {
+    const matcher = (p: Player) =>
+      variant === "veterans" ? isVeteran(p) : !isVeteran(p);
+    setPlayers(prev => {
+      const groupPlayers = prev.filter(matcher);
+      const otherPlayers = prev.filter(p => !matcher(p));
+      const idSet = new Set(updated.map(p => p.player));
+      let i = 0;
+      const newGroup = groupPlayers.map(p =>
+        idSet.has(p.player) ? updated[i++] : p
+      );
+      if (variant === "veterans") {
+        return [...newGroup, ...otherPlayers];
+      }
+      return [...otherPlayers, ...newGroup];
+    });
+    setIsDirty(true);
+  };
+
+  const handleClearAll = () => {
+    if (window.confirm("This will remove all players. Continue?")) {
+      setPlayers([]);
+      setIsDirty(true);
+    }
+  };
+
+  const handleSaveRankings = () => {
+    const veterans = players
+      .filter(isVeteran)
+      .map((p, index) => ({ ...p, group: "veterans", rank: index + 1 }));
+    const young = players
+      .filter(p => !isVeteran(p))
+      .map((p, index) => ({ ...p, group: "young", rank: index + 1 }));
+    const all = [...veterans, ...young];
+    if (all.length === 0) return;
+
+    const headers = [
+      "player",
+      "pos",
+      "ecr",
+      "age",
+      "rdr_team",
+      "team_full",
+      "years_of_experience",
+      "group",
+      "rank",
+    ] as const;
+    const escape = (val: unknown) =>
+      `"${String(val ?? "").replace(/"/g, '""')}"`;
+    const csv = [
+      headers.map(escape).join(","),
+      ...all.map((row) =>
+        headers
+          .map((h) => escape((row as Record<string, unknown>)[h]))
+          .join(",")
+      ),
+    ].join("\n");
+
+    const blob = new Blob([csv], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "rankings.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+    setIsDirty(false);
+  };
+
+  const handleLoadRankings = () => {
+    if (isDirty && !window.confirm("Unsaved changes will be lost. Continue?")) {
+      return;
+    }
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".csv";
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const text = String(event.target?.result || "");
+        const lines = text.trim().split(/\r?\n/);
+        const header = lines.shift();
+        if (!header) return;
+        const headers = header
+          .split(",")
+          .map((h) => h.replace(/^"|"$/g, ""));
+        const records = lines.map((line) => {
+          const values = line.match(/(?:"[^"]*(?:""[^"]*)*"|[^,])+/g) || [];
+          const obj: Record<string, string> = {};
+          headers.forEach((h, i) => {
+            const raw = values[i] || "";
+            obj[h] = raw.replace(/^"|"$/g, "").replace(/""/g, '"');
+          });
+          return obj;
+        });
+        const parsed: (Player & { group: string; rank: number })[] = records.map(
+          (r) => ({
+            player: r.player,
+            pos: r.pos,
+            ecr: Number(r.ecr),
+            age: Number(r.age),
+            rdr_team: r.rdr_team,
+            team_full: r.team_full,
+            years_of_experience:
+              r.years_of_experience === "" ? null : Number(r.years_of_experience),
+            group: r.group,
+            rank: Number(r.rank),
+          })
+        );
+        parsed.sort((a, b) =>
+          a.group === b.group ? a.rank - b.rank : a.group.localeCompare(b.group)
+        );
+        const cleaned: Player[] = parsed.map(({ group, rank, ...rest }) => rest);
+        setPlayers(cleaned);
+        setIsDirty(false);
+      };
+      reader.readAsText(file);
+    };
+    input.click();
   };
 
   const handleRetry = async () => {
@@ -84,25 +240,34 @@ export function DynastyDashboard() {
       : getPlayersByPosition(selectedPosition);
     
   const veteranPlayers = selectedPosition === "ALL"
-    ? players.filter(p => p.years_of_experience !== null && p.years_of_experience >= 2)
+    ? players.filter(isVeteran)
     : getVeteranPlayers(selectedPosition);
 
   const youngPlayers = selectedPosition === "ALL"
-    ? players.filter(p => p.years_of_experience === null || p.years_of_experience <= 1)
+    ? players.filter(p => !isVeteran(p))
     : getYoungPlayers(selectedPosition);
 
   const filteredVeterans = searchQuery
-    ? veteranPlayers.filter(p => p.player.toLowerCase().includes(searchQuery.toLowerCase()))
+    ? veteranPlayers.filter(p =>
+        p.player.toLowerCase().includes(searchQuery.toLowerCase())
+      )
     : veteranPlayers;
 
   const filteredYoung = searchQuery
-    ? youngPlayers.filter(p => p.player.toLowerCase().includes(searchQuery.toLowerCase()))
+    ? youngPlayers.filter(p =>
+        p.player.toLowerCase().includes(searchQuery.toLowerCase())
+      )
     : youngPlayers;
 
   return (
     <div className="min-h-screen bg-gradient-background">
       <div className="container mx-auto px-4 py-6 space-y-6">
-        <DashboardHeader onSearch={handleSearch} />
+        <DashboardHeader
+          onSearch={handleSearch}
+          onSaveRankings={handleSaveRankings}
+          onLoadRankings={handleLoadRankings}
+          onClearAll={handleClearAll}
+        />
         
         <TierGuide />
         
@@ -125,17 +290,27 @@ export function DynastyDashboard() {
             players={filteredVeterans}
             variant="veterans"
             onAddPlayer={handleAddPlayer}
+            onEditPlayer={handleEditPlayer}
+            onReorder={list => handleReorder(list, "veterans")}
           />
-          
+
           <PlayerRankingsTable
             title="Young Talent"
             subtitle="Rookies & Sophomores"
             players={filteredYoung}
             variant="young"
             onAddPlayer={handleAddPlayer}
+            onEditPlayer={handleEditPlayer}
+            onReorder={list => handleReorder(list, "young")}
           />
         </div>
       </div>
+      <PlayerFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSave={handleSavePlayer}
+        player={editingPlayer ?? undefined}
+      />
       <DataStatus />
     </div>
   );

--- a/src/components/PlayerFormDialog.tsx
+++ b/src/components/PlayerFormDialog.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import type { Player } from "@/hooks/usePlayerData";
+
+interface PlayerFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (player: Player) => void;
+  player?: Player;
+}
+
+export function PlayerFormDialog({
+  open,
+  onOpenChange,
+  onSave,
+  player,
+}: PlayerFormDialogProps) {
+  const [form, setForm] = useState({
+    player: "",
+    pos: "",
+    ecr: "",
+    age: "",
+    rdr_team: "",
+    team_full: "",
+    years_of_experience: "",
+  });
+
+  useEffect(() => {
+    if (player) {
+      setForm({
+        player: player.player,
+        pos: player.pos,
+        ecr: String(player.ecr),
+        age: String(player.age),
+        rdr_team: player.rdr_team,
+        team_full: player.team_full,
+        years_of_experience:
+          player.years_of_experience === null
+            ? ""
+            : String(player.years_of_experience),
+      });
+    } else {
+      setForm({
+        player: "",
+        pos: "",
+        ecr: "",
+        age: "",
+        rdr_team: "",
+        team_full: "",
+        years_of_experience: "",
+      });
+    }
+  }, [player, open]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = () => {
+    onSave({
+      player: form.player,
+      pos: form.pos,
+      ecr: Number(form.ecr),
+      age: Number(form.age),
+      rdr_team: form.rdr_team,
+      team_full: form.team_full,
+      years_of_experience:
+        form.years_of_experience === ""
+          ? null
+          : Number(form.years_of_experience),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{player ? "Edit Player" : "Add Player"}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="player">Name</Label>
+            <Input id="player" name="player" value={form.player} onChange={handleChange} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="pos">Position</Label>
+            <Input id="pos" name="pos" value={form.pos} onChange={handleChange} />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="age">Age</Label>
+              <Input id="age" name="age" type="number" value={form.age} onChange={handleChange} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ecr">ECR</Label>
+              <Input id="ecr" name="ecr" type="number" value={form.ecr} onChange={handleChange} />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="rdr_team">Team</Label>
+            <Input id="rdr_team" name="rdr_team" value={form.rdr_team} onChange={handleChange} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="team_full">Team Full</Label>
+            <Input id="team_full" name="team_full" value={form.team_full} onChange={handleChange} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="years_of_experience">Years of Experience</Label>
+            <Input
+              id="years_of_experience"
+              name="years_of_experience"
+              type="number"
+              value={form.years_of_experience}
+              onChange={handleChange}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/hooks/usePlayerData.ts
+++ b/src/hooks/usePlayerData.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 
-interface Player {
+export interface Player {
   player: string;
   pos: string;
   ecr: number;
@@ -40,7 +40,15 @@ export function usePlayerData() {
 
       // Transform data with real years_of_experience from the view
       // This is the correct logic now that we have the proper data
-      const transformedPlayers = (data || []).map((row: any) => ({
+      interface Row {
+        player: string;
+        pos: string;
+        ecr: number;
+        team: string;
+        years_of_experience: number | null;
+      }
+
+      const transformedPlayers = (data || []).map((row: Row) => ({
         player: row.player,
         pos: row.pos,
         ecr: Number(row.ecr),
@@ -102,6 +110,7 @@ export function usePlayerData() {
     getVeteranPlayers,
     getYoungPlayers,
     searchPlayers,
-    refetch: fetchPlayers
+    refetch: fetchPlayers,
+    setPlayers
   };
 }


### PR DESCRIPTION
## Summary
- export rankings for all positions with group ranks
- allow adding or editing players through a modal form
- add clear-all control with confirmation and propagate drag reorders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in components/ui/textarea.tsx and @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d2fea6a2c83248ecb72b014162a7d